### PR TITLE
Check individual messages for distinct sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Head
+- Check individual messages for distinct sources, then group messages by those sources,
+  instead of always using the PostCSS Result's source.
 - Output empty string from `formatter` if there are no messages, instead of `undefined`.
 
 ## 1.2.1

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,8 +1,7 @@
 var chalk = require('chalk');
 var path = require('path');
 var symbols = require('log-symbols');
-var sortByAll = require('lodash.sortbyall');
-var property = require('lodash.property');
+var _ = require('lodash');
 
 module.exports = function(opts) {
   var options = opts || {};
@@ -15,7 +14,7 @@ module.exports = function(opts) {
 
     if (!messages.length) return '';
 
-    var orderedMessages = sortByAll(
+    var orderedMessages = _.sortByAll(
       messages,
       function(m) {
         if (!m.line) return 1;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,5 +1,5 @@
 var chalk = require('chalk');
-var difference = require('lodash.difference');
+var _ = require('lodash');
 var defaultFormatter = require('./formatter');
 
 module.exports = function(opts) {
@@ -19,16 +19,24 @@ module.exports = function(opts) {
           return options.plugins.indexOf(message.plugin) !== -1;
         });
 
-    var source = (!result.root.source) ? undefined
+    var resultSource = (!result.root.source) ? ''
       : result.root.source.input.file || result.root.source.input.id
 
-    var report = formatter({
-      messages: messagesToLog,
-      source: source,
+    var sourceGroupedMessages = _.groupBy(messagesToLog, function(message) {
+      if (!message.node || !message.node.source) return resultSource;
+      return message.node.source.input.file || message.node.source.input.id;
+    });
+
+    var report = '';
+    _.forOwn(sourceGroupedMessages, function(messages, source) {
+      report += formatter({
+        messages: messages,
+        source: source,
+      });
     });
 
     if (options.clearMessages) {
-      result.messages = difference(result.messages, messagesToLog);
+      result.messages = _.difference(result.messages, messagesToLog);
     }
 
     if (!report) return;

--- a/package.json
+++ b/package.json
@@ -28,15 +28,12 @@
   "homepage": "https://github.com/postcss/postcss-reporter",
   "devDependencies": {
     "eslint": "1.3.1",
-    "lodash.clonedeep": "3.0.2",
     "stylelint": "1.0.1",
     "tape": "4.2.0"
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "lodash.difference": "^3.2.1",
-    "lodash.property": "^3.1.2",
-    "lodash.sortbyall": "^3.2.1",
+    "lodash": "^3.10.1",
     "log-symbols": "^1.0.2",
     "postcss": "^5.0.0"
   }

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var cloneDeep = require('lodash.clonedeep');
+var _ = require('lodash');
 var reporter = require('../lib/reporter');
 
 var mockSimpleResult = {
@@ -74,7 +74,7 @@ test('reporter with simple mock result and specified plugin', function(t) {
 });
 
 test('reporter with simple mock result and clearMessages', function(t) {
-  var cloneResult = cloneDeep(mockSimpleResult);
+  var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -86,7 +86,7 @@ test('reporter with simple mock result and clearMessages', function(t) {
 });
 
 test('reporter with simple mock result, specified plugins, and clearMessages', function(t) {
-  var cloneResult = cloneDeep(mockSimpleResult);
+  var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -108,7 +108,7 @@ test('reporter with simple mock result, specified plugins, and clearMessages', f
 });
 
 test('reporter with simple mock result and throwError', function(t) {
-  var cloneResult = cloneDeep(mockSimpleResult);
+  var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -172,6 +172,186 @@ test('reporter with mock containing no source', function(t) {
     formatter: mockFormatter(tracker),
   });
   testReporter(null, mockResultNoSource);
-  t.equal(tracker.source, undefined);
+  t.equal(tracker.source, '');
   t.end();
 })
+
+var mockWarningNodeResult = {
+  messages: [
+    {
+      type: 'warning',
+      plugin: 'foo',
+      text: 'foo warning',
+      node: {
+        source: {
+          input: {
+            file: 'foo.css',
+          },
+        },
+      },
+    },
+    {
+      type: 'warning',
+      plugin: 'baz',
+      text: 'baz warning',
+      node: {
+        source: {
+          input: {
+            file: 'bar.css',
+          },
+        },
+      },
+    },
+    {
+      type: 'error',
+      plugin: 'pat',
+      text: 'pat error',
+      node: {
+        source: {
+          input: {
+            id: '<input css 2>',
+          },
+        },
+      },
+    },
+    {
+      type: 'warning',
+      plugin: 'bar',
+      text: 'bar warning',
+      node: {
+        source: {
+          input: {
+            file: 'foo.css',
+          },
+        },
+      },
+    },
+    {
+      type: 'error',
+      plugin: 'hoo',
+      text: 'hoo error',
+      node: {
+        source: {
+          input: {
+            id: '<input css 2>',
+          },
+        },
+      },
+    },
+    {
+      type: 'error',
+      plugin: 'hah',
+      text: 'hah error',
+    },
+  ],
+  root: {
+    source: {
+      input: {
+        id: '<input css 1>',
+      },
+    },
+  },
+};
+
+function mockMultiSourceFormatter(tracker) {
+  return function(obj) {
+    tracker.push(obj);
+    return 'bogus report';
+  };
+}
+
+test('reporter with warnings that messages that each have nodes', function(t) {
+  var tracker = [];
+  var testReporter = reporter({
+    formatter: mockMultiSourceFormatter(tracker),
+  });
+  testReporter(null, mockWarningNodeResult);
+  t.deepEqual(tracker, [
+    {
+      source: 'foo.css',
+      messages: [
+        {
+          type: 'warning',
+          plugin: 'foo',
+          text: 'foo warning',
+          node: {
+            source: {
+              input: {
+                file: 'foo.css',
+              },
+            },
+          },
+        },
+        {
+          type: 'warning',
+          plugin: 'bar',
+          text: 'bar warning',
+          node: {
+            source: {
+              input: {
+                file: 'foo.css',
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      source: 'bar.css',
+      messages: [
+        {
+          type: 'warning',
+          plugin: 'baz',
+          text: 'baz warning',
+          node: {
+            source: {
+              input: {
+                file: 'bar.css',
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      source: '<input css 2>',
+      messages: [
+        {
+          type: 'error',
+          plugin: 'pat',
+          text: 'pat error',
+          node: {
+            source: {
+              input: {
+                id: '<input css 2>',
+              },
+            },
+          },
+        },
+        {
+          type: 'error',
+          plugin: 'hoo',
+          text: 'hoo error',
+          node: {
+            source: {
+              input: {
+                id: '<input css 2>',
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      source: '<input css 1>',
+      messages: [
+        {
+          type: 'error',
+          plugin: 'hah',
+          text: 'hah error',
+        },
+      ],
+    },
+  ]);
+  t.end();
+});


### PR DESCRIPTION
Instead of using the PostCSS Result's source and grouping all
messages under that, check each individual message for a node
with a distinct source, group messages according to whether
their nodes' share sources, and only use the Result's source
if the message does not have its own node with a source.

This addresses #12.

@MadLittleMods and @ben-eb I thought you might want to review this,
see if it fits your expectations. It would also be great if you could help
test this branch out in a real situation (instead of just mocks results)
so we can see if it really works :)