### PR TITLE
Add new option to clear messages for others plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ By default, only messages with `type: "warning"` warnings are logged. (These are
 
 For example, `function(message) { return true }` will only every message, regardless of the plugin or whether it's a warning or not.
 
-**clearMessagesFilter** (function)
+**clearAllMessages** (function)
 
 Provide a filter function to clear the messages. This prevents other plugins, or the whatever runner you use, from logging.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ gulp.task('css', function() {
 
 ## Options
 
-**clearMessages** (boolean, default = `false`)
+**clearReportedMessages** (boolean, default = `false`)
 
 If true, the plugin will clear the result's messages after it logs them. This prevents other plugins, or the whatever runner you use, from logging the same information again and causing confusion.
 
@@ -89,6 +89,12 @@ Provide a filter function. It receives the message object and returns a truthy o
 By default, only messages with `type: "warning"` warnings are logged. (These are the messages produced when the plugin author uses PostCSS's `warn()` function.)
 
 For example, `function(message) { return true }` will only every message, regardless of the plugin or whether it's a warning or not.
+
+**clearMessagesFilter** (function)
+
+Provide a filter function to clear the messages. This prevents other plugins, or the whatever runner you use, from logging.
+
+It receives the message object and returns a truthy or falsy value, indicating whether that particular message should be cleared or not for others plugins.
 
 **throwError** (boolean, default = `false`)
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,9 @@ By default, only messages with `type: "warning"` warnings are logged. (These are
 
 For example, `function(message) { return true }` will only every message, regardless of the plugin or whether it's a warning or not.
 
-**clearAllMessages** (function)
+**clearAllMessages** (boolean, default = `false`)
 
-Provide a filter function to clear the messages. This prevents other plugins, or the whatever runner you use, from logging.
-
-It receives the message object and returns a truthy or falsy value, indicating whether that particular message should be cleared or not for others plugins.
+If `true`, not pass any messages into other plugins, or the whatever runner you use, for logging.
 
 **throwError** (boolean, default = `false`)
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -51,9 +51,18 @@ module.exports = function(opts) {
       });
     });
 
-    if (options.clearMessages) {
+    if (options.clearReportedMessages) {
       result.messages = _.difference(result.messages, messagesToLog);
     }
+
+    if (typeof options.clearMessagesFilter === 'function') {
+      var messagesToClear = result.messages
+        .filter(pluginFilter)
+        .filter(options.clearMessagesFilter);
+      result.messages = _.difference(result.messages, messagesToClear);
+      console.log(result.messages);
+    }
+
 
     if (!report) return;
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,10 +55,10 @@ module.exports = function(opts) {
       result.messages = _.difference(result.messages, messagesToLog);
     }
 
-    if (typeof options.clearMessagesFilter === 'function') {
+    if (typeof options.clearAllMessages === 'function') {
       var messagesToClear = result.messages
         .filter(pluginFilter)
-        .filter(options.clearMessagesFilter);
+        .filter(options.clearAllMessages);
       result.messages = _.difference(result.messages, messagesToClear);
     }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -60,7 +60,6 @@ module.exports = function(opts) {
         .filter(pluginFilter)
         .filter(options.clearMessagesFilter);
       result.messages = _.difference(result.messages, messagesToClear);
-      console.log(result.messages);
     }
 
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,10 +55,8 @@ module.exports = function(opts) {
       result.messages = _.difference(result.messages, messagesToLog);
     }
 
-    if (typeof options.clearAllMessages === 'function') {
-      var messagesToClear = result.messages
-        .filter(pluginFilter)
-        .filter(options.clearAllMessages);
+    if (options.clearAllMessages) {
+      var messagesToClear = result.messages.filter(pluginFilter);
       result.messages = _.difference(result.messages, messagesToClear);
     }
 

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -215,12 +215,12 @@ test('reporter with simple mock result, whitelisted plugins and clearReportedMes
   t.end();
 });
 
-test('reporter with simple mock result and clearMessagesFilter', function(t) {
+test('reporter with simple mock result and clearAllMessages', function(t) {
   var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
-    clearMessagesFilter: function(message) {
+    clearAllMessages: function(message) {
       return (message.text === 'foo warning' || message.text === 'bar warning');
     },
   });
@@ -240,13 +240,13 @@ test('reporter with simple mock result and clearMessagesFilter', function(t) {
   t.end();
 });
 
-test('reporter with simple mock result, clearMessagesFilter and whitelisted plugins', function(t) {
+test('reporter with simple mock result, clearAllMessages and whitelisted plugins', function(t) {
   var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
     plugins: ['foo'],
-    clearMessagesFilter: function(message) {
+    clearAllMessages: function(message) {
       return (message.text === 'foo warning' || message.text === 'bar warning');
     },
   });

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -181,25 +181,25 @@ test('reporter with simple mock result and empty plugins', function(t) {
   t.end();
 });
 
-test('reporter with simple mock result and clearMessages', function(t) {
+test('reporter with simple mock result and clearReportedMessages', function(t) {
   var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
-    clearMessages: true,
+    clearReportedMessages: true,
   });
   testReporter(null, cloneResult);
   t.deepEqual(cloneResult.messages, []);
   t.end();
 });
 
-test('reporter with simple mock result, whitelisted plugins, and clearMessages', function(t) {
+test('reporter with simple mock result, whitelisted plugins and clearReportedMessages', function(t) {
   var cloneResult = _.cloneDeep(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
     plugins: ['baz', 'foo'],
-    clearMessages: true,
+    clearReportedMessages: true,
   });
   testReporter(null, cloneResult);
   t.deepEqual(
@@ -212,6 +212,62 @@ test('reporter with simple mock result, whitelisted plugins, and clearMessages',
       },
     ]
   );
+  t.end();
+});
+
+test('reporter with simple mock result and clearMessagesFilter', function(t) {
+  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var tracker = {};
+  var testReporter = reporter({
+    formatter: mockFormatter(tracker),
+    clearMessagesFilter: function(message) {
+      return (message.text === 'foo warning' || message.text === 'bar warning');
+    },
+  });
+  testReporter(null, cloneResult);
+  t.deepEqual(cloneResult.messages, [
+    {
+      type: 'warning',
+      plugin: 'baz',
+      text: 'baz warning',
+    },
+    {
+      type: 'warning',
+      plugin: 'baz',
+      text: 'baz error',
+    },
+  ]);
+  t.end();
+});
+
+test('reporter with simple mock result, clearMessagesFilter and whitelisted plugins', function(t) {
+  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var tracker = {};
+  var testReporter = reporter({
+    formatter: mockFormatter(tracker),
+    plugins: ['foo'],
+    clearMessagesFilter: function(message) {
+      return (message.text === 'foo warning' || message.text === 'bar warning');
+    },
+  });
+  testReporter(null, cloneResult);
+  t.deepEqual(cloneResult.messages, [
+    {
+      type: 'warning',
+      plugin: 'bar',
+      text: 'bar warning',
+    },
+    {
+      type: 'warning',
+      plugin: 'baz',
+      text: 'baz warning',
+    },
+    {
+      type: 'warning',
+      plugin: 'baz',
+      text: 'baz error',
+    },
+  ]);
   t.end();
 });
 

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -220,23 +220,10 @@ test('reporter with simple mock result and clearAllMessages', function(t) {
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
-    clearAllMessages: function(message) {
-      return (message.text === 'foo warning' || message.text === 'bar warning');
-    },
+    clearAllMessages: true,
   });
   testReporter(null, cloneResult);
-  t.deepEqual(cloneResult.messages, [
-    {
-      type: 'warning',
-      plugin: 'baz',
-      text: 'baz warning',
-    },
-    {
-      type: 'warning',
-      plugin: 'baz',
-      text: 'baz error',
-    },
-  ]);
+  t.deepEqual(cloneResult.messages, []);
   t.end();
 });
 
@@ -246,28 +233,29 @@ test('reporter with simple mock result, clearAllMessages and whitelisted plugins
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
     plugins: ['foo'],
-    clearAllMessages: function(message) {
-      return (message.text === 'foo warning' || message.text === 'bar warning');
-    },
+    clearAllMessages: true,
   });
   testReporter(null, cloneResult);
-  t.deepEqual(cloneResult.messages, [
-    {
-      type: 'warning',
-      plugin: 'bar',
-      text: 'bar warning',
-    },
-    {
-      type: 'warning',
-      plugin: 'baz',
-      text: 'baz warning',
-    },
-    {
-      type: 'warning',
-      plugin: 'baz',
-      text: 'baz error',
-    },
-  ]);
+  t.deepEqual(
+    cloneResult.messages,
+    [
+      {
+        type: 'warning',
+        plugin: 'bar',
+        text: 'bar warning',
+      },
+      {
+        type: 'warning',
+        plugin: 'baz',
+        text: 'baz warning',
+      },
+      {
+        type: 'warning',
+        plugin: 'baz',
+        text: 'baz error',
+      },
+    ]
+  );
   t.end();
 });
 


### PR DESCRIPTION
I renamed `clearMessages` option to `clearReportedMessages` option.
And added new option `clearMessagesFilter` function. This function can clear messages for others plugins.