### PR TITLE
Changed: compatibility with `postcss` v6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
   "homepage": "https://github.com/postcss/postcss-reporter",
   "devDependencies": {
     "eslint": "1.3.1",
-    "less": "2.7.1",
+    "less": "2.7.2",
     "source-map": "0.5.6",
-    "stylelint": "6.8.0",
-    "tape": "4.6.0"
+    "stylelint": "7.10.1",
+    "tape": "4.6.3"
   },
   "dependencies": {
     "chalk": "^1.0.0",
     "lodash": "^4.1.0",
     "log-symbols": "^1.0.2",
-    "postcss": "^5.0.0"
+    "postcss": "^6.0.1"
   }
 }


### PR DESCRIPTION
/cc @davidtheclark	
Some other plugins use `postcss-reporter`, example `stylehacks`. We need release new version with compatibility with `postcss` v6.

Ref: https://github.com/postcss/postcss-reporter/issues/38