### PR TITLE
Update Travis CI to test against some recent Node.js releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
+  - "8"
+  - "6"
+  - "4"
   - "0.12"
   - "stable"


### PR DESCRIPTION
If all goes well after merging, dropping `0.12` and `stable` in a follow up PR would be 👌 