### PR TITLE
Fix an issue where messages without text property are shown as `undefined [plugin-name]`

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -10,7 +10,9 @@ module.exports = function(opts) {
   var positionless = options.positionless || 'first';
 
   return function(input) {
-    var messages = input.messages;
+    var messages = input.messages.filter(function(message) {
+      return typeof message.text === 'string';
+    });
     var source = input.source;
 
     if (!messages.length) return '';

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -256,3 +256,30 @@ test('defaultFormatter with real sourcemaps', function(t) {
   );
   t.end();
 });
+
+var textlessMessages = [
+  {
+    type: 'warning',
+    plugin: 'foo',
+  },
+  {
+    type: 'dependency',
+    plugin: 'bar',
+    file: 'bar file',
+  },
+];
+
+var textlessMessagesOutput = '';
+
+test('defaultFormatter with messages without text property', function(t) {
+  t.equal(
+    stripColor(defaultFormatter({
+      messages: textlessMessages,
+      source: '<input css 1>',
+    })),
+    textlessMessagesOutput,
+    'basic'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
According to the postcss API document, [required properties of `Message` are only `type` and `plugin`](http://api.postcss.org/Result.html#messages). `postcss-import`, for example, [pushes messages without `text` property](https://github.com/postcss/postcss-import/blob/f98dd1a5a6a987c8cf197db46644765a4d43d73a/index.js#L198-L205). `postcss-reporter`, however, [assumes each message has `text`](https://github.com/postcss/postcss-reporter/blob/f29e44b30aeb9931e7dfea4aceed0de4f851f864/lib/formatter.js#L68), causing `undefined` to be shown as a message body for such messages.

Due to this issue, when `postcss-import` and `postcss-calc` are used in this order, the same number of `undefined` messages as that of `@import` rules existing in CSS files to be concatinated appear in a console, which is quite annoying. You can get code to reproduce this issue at https://github.com/nodaguti/postcss-calc-warning.

This PR fixes the issue by filtering out messages that don't have `text` property in the formatter.