### PR TITLE
chore: drop prod dependency on chalk.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,8 +1,10 @@
 var { bold, underline, yellow } = require('colorette');
 var path = require('path');
-var symbols = require('log-symbols');
 var sortBy = require('lodash.sortby');
 var util = require('./util');
+
+var supportsLargeCharset = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color';
+var warningSymbol = supportsLargeCharset ? '⚠' : '!!';
 
 module.exports = function(opts) {
   var options = opts || {};
@@ -64,7 +66,7 @@ module.exports = function(opts) {
       }
 
       if (!options.noIcon && message.type === 'warning') {
-        str += yellow(symbols.warning + '  ');
+        str += yellow(warningSymbol + '  ');
       }
 
       str += message.text;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "7.10.0",
     "less": "3.12.2",
     "lodash": "^4.17.20",
+    "log-symbols": "^4.0.0",
     "postcss": "^8.1.0",
     "source-map": "0.7.3",
     "strip-color": "^0.1.0",
@@ -46,7 +47,6 @@
     "lodash.forown": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
-    "lodash.sortby": "^4.7.0",
-    "log-symbols": "^4.0.0"
+    "lodash.sortby": "^4.7.0"
   }
 }


### PR DESCRIPTION
This pull request drops `node_modules` from 592K to 364K (with `yarn install --prod`). Without it,  this package installs  `colorette`, but also `chalk`, since `log-symbols` depends on it.
I've kept `log-symbols` in the tests as a sanity check.