### PR TITLE
Remove lodash dependencies

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,6 @@
 var pico = require('picocolors');
 var path = require('path');
-var sortBy = require('lodash.sortby');
+var firstBy = require('thenby');
 var util = require('./util');
 
 var supportsLargeCharset =
@@ -8,6 +8,25 @@ var supportsLargeCharset =
   process.env.CI ||
   process.env.TERM === 'xterm-256color';
 var warningSymbol = supportsLargeCharset ? '⚠' : '!!';
+
+function createSortFunction(positionless, sortByPosition) {
+  var positionValue = 0
+
+  if (positionless === 'any') { positionValue = 1; }
+  if (positionless === 'first') { positionValue = 2; }
+  if (positionless === 'last') { positionValue = 0; }
+
+  var sortFunction = firstBy((m) => {
+    if (!m.line) return 1;
+    return positionValue;
+  })
+
+  if (sortByPosition) {
+    sortFunction = sortFunction.thenBy('line').thenBy('column');
+  }
+
+  return sortFunction;
+}
 
 module.exports = function (opts) {
   var options = opts || {};
@@ -17,6 +36,8 @@ module.exports = function (opts) {
       : true;
   var positionless = options.positionless || 'first';
 
+  var sortFunction = createSortFunction(positionless, sortByPosition);
+
   return function (input) {
     var messages = input.messages.filter(function (message) {
       return typeof message.text === 'string';
@@ -25,23 +46,7 @@ module.exports = function (opts) {
 
     if (!messages.length) return '';
 
-    var orderedMessages = sortBy(
-      messages,
-      function (m) {
-        if (!m.line) return 1;
-        if (positionless === 'any') return 1;
-        if (positionless === 'first') return 2;
-        if (positionless === 'last') return 0;
-      },
-      function (m) {
-        if (!sortByPosition) return 1;
-        return m.line;
-      },
-      function (m) {
-        if (!sortByPosition) return 1;
-        return m.column;
-      }
-    );
+    var orderedMessages = messages.sort(sortFunction);
 
     var output = '\n';
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,9 +1,6 @@
 var defaultFormatter = require('./formatter');
 var pico = require('picocolors');
 var util = require('./util');
-var groupBy = require('lodash.groupby');
-var forOwn = require('lodash.forown');
-var difference = require('lodash.difference');
 
 module.exports = function (opts = {}) {
   var formatter =
@@ -48,25 +45,35 @@ module.exports = function (opts = {}) {
         ? ''
         : result.root.source.input.file || result.root.source.input.id;
 
-      var sourceGroupedMessages = groupBy(messagesToLog, (message) => {
-        return util.getLocation(message).file || resultSource;
-      });
+      var sourceGroupedMessages = messagesToLog.reduce((grouped, message) => {
+        const key = util.getLocation(message).file || resultSource;
+
+        if (!grouped.hasOwnProperty(key)) {
+          grouped[key] = [];
+        }
+
+        grouped[key].push(message);
+
+        return grouped;
+      }, {});
 
       var report = '';
-      forOwn(sourceGroupedMessages, function (messages, source) {
-        report += formatter({
-          messages: messages,
-          source: source,
-        });
-      });
+      for (const source in sourceGroupedMessages) {
+        if (sourceGroupedMessages.hasOwnProperty(source)) {
+          report += formatter({
+            messages: sourceGroupedMessages[source],
+            source: source,
+          });
+        }
+      }
 
       if (opts.clearReportedMessages) {
-        result.messages = difference(result.messages, messagesToLog);
+        result.messages = result.messages.filter(message => !messagesToLog.includes(message));
       }
 
       if (opts.clearAllMessages) {
         var messagesToClear = result.messages.filter(pluginFilter);
-        result.messages = difference(result.messages, messagesToClear);
+        result.messages = result.messages.filter(message => !messagesToClear.includes(message));
       }
 
       if (!report) return;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,3 @@
-var delve = require('dlv');
-
 exports.getLocation = function (message) {
   var messageNode = message.node;
 
@@ -8,7 +6,7 @@ exports.getLocation = function (message) {
     column: message.column,
   };
 
-  var messageInput = delve(messageNode, 'source.input');
+  var messageInput = messageNode && messageNode.source && messageNode.source.input;
 
   if (!messageInput) return location;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,4 @@
-var get = require('lodash.get');
+var delve = require('dlv');
 
 exports.getLocation = function (message) {
   var messageNode = message.node;
@@ -8,7 +8,7 @@ exports.getLocation = function (message) {
     column: message.column,
   };
 
-  var messageInput = get(messageNode, 'source.input');
+  var messageInput = delve(messageNode, 'source.input');
 
   if (!messageInput) return location;
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "clean-publish": "^3.4.1",
     "eslint": "8.0.0",
     "less": "3.12.2",
-    "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "postcss": "^8.3.9",
     "source-map": "0.7.3",
@@ -42,12 +41,9 @@
     "tape": "^5.3.1"
   },
   "dependencies": {
-    "lodash.difference": "^4.5.0",
-    "lodash.forown": "^4.4.0",
-    "lodash.get": "^4.4.2",
-    "lodash.groupby": "^4.6.0",
-    "lodash.sortby": "^4.7.0",
-    "picocolors": "^1.0.0"
+    "dlv": "^1.1.3",
+    "picocolors": "^1.0.0",
+    "thenby": "^1.3.4"
   },
   "clean-publish": {
     "cleanDocs": true

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "tape": "^5.3.1"
   },
   "dependencies": {
-    "dlv": "^1.1.3",
     "picocolors": "^1.0.0",
     "thenby": "^1.3.4"
   },

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,5 +1,4 @@
 var test = require('tape');
-var _ = require('lodash');
 var reporter = require('../lib/reporter');
 
 var mockSimpleResult = {
@@ -33,6 +32,10 @@ var mockSimpleResult = {
     },
   },
 };
+
+function clone(toClone) {
+  return JSON.parse(JSON.stringify(toClone));
+}
 
 test('reporter with simple mock result', function(t) {
   var tracker = {};
@@ -142,7 +145,7 @@ test('reporter with simple mock result and blacklisted plugins', function(t) {
 });
 
 test('reporter with simple mock result and function-filtered plugins', function(t) {
-  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var cloneResult = clone(mockSimpleResult);
   cloneResult.messages.push(
     {
       type: 'error',
@@ -184,7 +187,7 @@ test('reporter with simple mock result and empty plugins', function(t) {
 });
 
 test('reporter with simple mock result and clearReportedMessages', function(t) {
-  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var cloneResult = clone(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -196,7 +199,7 @@ test('reporter with simple mock result and clearReportedMessages', function(t) {
 });
 
 test('reporter with simple mock result, whitelisted plugins and clearReportedMessages', function(t) {
-  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var cloneResult = clone(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -218,7 +221,7 @@ test('reporter with simple mock result, whitelisted plugins and clearReportedMes
 });
 
 test('reporter with simple mock result and clearAllMessages', function(t) {
-  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var cloneResult = clone(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -230,7 +233,7 @@ test('reporter with simple mock result and clearAllMessages', function(t) {
 });
 
 test('reporter with simple mock result, clearAllMessages and whitelisted plugins', function(t) {
-  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var cloneResult = clone(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),
@@ -262,7 +265,7 @@ test('reporter with simple mock result, clearAllMessages and whitelisted plugins
 });
 
 test('reporter with simple mock result and throwError', function(t) {
-  var cloneResult = _.cloneDeep(mockSimpleResult);
+  var cloneResult = clone(mockSimpleResult);
   var tracker = {};
   var testReporter = reporter({
     formatter: mockFormatter(tracker),

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,6 +641,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dlv@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1601,42 +1606,17 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
-
-lodash.forown@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.forown/-/lodash.forown-4.4.0.tgz#85115cf04f73ef966eced52511d3893cc46683af"
-  integrity sha1-hRFc8E9z75ZuztUlEdOJPMRmg68=
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
-lodash.groupby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
-  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2541,6 +2521,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+thenby@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/thenby/-/thenby-1.3.4.tgz#81581f6e1bb324c6dedeae9bfc28e59b1a2201cc"
+  integrity sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==
 
 through@^2.3.8, through@~2.3.4:
   version "2.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,11 +641,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dlv@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
-  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
-
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"


### PR DESCRIPTION
Hi,

I'm trying to reduce the size of dependencies I import in my projects.

One thing that quite often comes up is the size of lodash modules when they're imported separately (lodash.*)
While the monolithic lodash import is also quite big, my approach has been to remove it when possible.
According to bundlephobia, that's where most of the size for postcss-reporter is : https://bundlephobia.com/package/postcss-reporter@7.0.4

Two dependencies were added as replacements, but they are very small:
* https://bundlephobia.com/package/thenby@1.3.4 (726B minified)
* https://bundlephobia.com/package/dlv@1.1.3 (253B minified)

This PR would reduce this package from 38K to ~4K

Here is the list of what I did for each imported package

## `lodash.sortby`

Replaced by `thenby` a smaller package that specializes in sorting, also the function has been extracted to be created only once and reused for multiple reports.

## `lodash.groupby`

Replaced by a `.reduce()`.

## `lodash.forown` 

Replaced by a for loop.

## `lodash.difference`

Replaced by `result.messages.filter(message => !messagesToLog.includes(message));`

## `lodash.get`

Replaced by `dlv`, much smaller package

## `lodash.clonedeep` in tests

Replaced by `JSON.parse(JSON.stringify(toClone))`